### PR TITLE
feature/mean-dollar-invested-age-metric-timebounds

### DIFF
--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -36,14 +36,13 @@ export const DormantCirculationTimebounds = newTimebounds(
   ['90d', '180d', '2y', '3y', '5y'],
   { key: 'dormant_circulation', label: 'Dormant Circulation' },
 )
-export const MeanDollarInvestedAgeTimebounds = newTimebounds(Metric.mean_dollar_invested_age, [
-  '90d',
-  '180d',
-  '365d',
-  '2y',
-  '3y',
-  '5y',
-])
+
+const MEAN_AGE_TIMEBOUNDS = ['90d', '180d', '365d', '2y', '3y', '5y']
+export const MeanAgeTimebounds = newTimebounds(Metric.mean_age, MEAN_AGE_TIMEBOUNDS)
+export const MeanDollarInvestedAgeTimebounds = newTimebounds(
+  Metric.mean_dollar_invested_age,
+  MEAN_AGE_TIMEBOUNDS,
+)
 
 Object.assign(
   Metric,
@@ -52,5 +51,6 @@ Object.assign(
   RealizedCapTimebounds,
   CirculationTimebounds,
   DormantCirculationTimebounds,
+  MeanAgeTimebounds,
   MeanDollarInvestedAgeTimebounds,
 )

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -36,6 +36,15 @@ export const DormantCirculationTimebounds = newTimebounds(
   ['90d', '180d', '2y', '3y', '5y'],
   { key: 'dormant_circulation', label: 'Dormant Circulation' },
 )
+export const MeanDollarInvestedAgeTimebounds = newTimebounds(Metric.mean_dollar_invested_age, [
+  '90d',
+  '180d',
+  '365d',
+  '2y',
+  '3y',
+  '5y',
+])
+
 Object.assign(
   Metric,
   MvrvTimebounds,
@@ -43,4 +52,5 @@ Object.assign(
   RealizedCapTimebounds,
   CirculationTimebounds,
   DormantCirculationTimebounds,
+  MeanDollarInvestedAgeTimebounds,
 )

--- a/src/metrics/selector/subitems.ts
+++ b/src/metrics/selector/subitems.ts
@@ -5,6 +5,7 @@ import {
   RealizedCapTimebounds,
   CirculationTimebounds,
   DormantCirculationTimebounds,
+  MeanAgeTimebounds,
   MeanDollarInvestedAgeTimebounds,
 } from '@/metrics'
 import { SelectorType } from './types'
@@ -80,6 +81,7 @@ export const Subitems = {
   [Metric.realized_value_usd.key]: Object.values(RealizedCapTimebounds),
   [Metric.circulation.key]: Object.values(CirculationTimebounds),
   [Metric.dormant_circulation_365d.key]: Object.values(DormantCirculationTimebounds),
+  [Metric.mean_age.key]: Object.values(MeanAgeTimebounds),
   [Metric.mean_dollar_invested_age.key]: Object.values(MeanDollarInvestedAgeTimebounds),
 
   [Metric.median_fees_usd.key]: [SelectorNode.FeesDistribution],

--- a/src/metrics/selector/subitems.ts
+++ b/src/metrics/selector/subitems.ts
@@ -5,6 +5,7 @@ import {
   RealizedCapTimebounds,
   CirculationTimebounds,
   DormantCirculationTimebounds,
+  MeanDollarInvestedAgeTimebounds,
 } from '@/metrics'
 import { SelectorType } from './types'
 import { SelectorNode } from './index'
@@ -79,6 +80,7 @@ export const Subitems = {
   [Metric.realized_value_usd.key]: Object.values(RealizedCapTimebounds),
   [Metric.circulation.key]: Object.values(CirculationTimebounds),
   [Metric.dormant_circulation_365d.key]: Object.values(DormantCirculationTimebounds),
+  [Metric.mean_dollar_invested_age.key]: Object.values(MeanDollarInvestedAgeTimebounds),
 
   [Metric.median_fees_usd.key]: [SelectorNode.FeesDistribution],
   [Metric.amount_in_top_holders.key]: [SelectorNode.HoldersDistributionTable],


### PR DESCRIPTION
## Summary
Supporting timebounds for the `mean_age` and `mean_dollar_invested_age` metric

## Screenshots
![CleanShot 2022-08-10 at 11 11 48@2x](https://user-images.githubusercontent.com/25135650/183863270-46debc4a-b8ed-4589-93fe-81ba9ccd29ae.jpg)

