### PR TITLE
Add active addresses new intervals

### DIFF
--- a/src/metrics/_onchain/index.ts
+++ b/src/metrics/_onchain/index.ts
@@ -98,6 +98,14 @@ const NetworkActivityMetric = each(
       label: 'Active Addresses 24h',
       node: 'bar',
     },
+    active_addresses_7d: {
+      label: 'Active Addresses 7d',
+      node: 'bar',
+    },
+    active_addresses_30d: {
+      label: 'Active Addresses 30d',
+      node: 'bar',
+    },
     circulation: {
       label: 'Circulation',
     },


### PR DESCRIPTION
Adding metrics to Sanbase:
- active_addresses_7d
- active_addresses_30d
- transactions_count
- payments_count