### PR TITLE
Add compound v3 metrics

### DIFF
--- a/src/metrics/_onchain/compound.ts
+++ b/src/metrics/_onchain/compound.ts
@@ -86,3 +86,80 @@ export const CompoundMetric = each(
     metric.group = 'Compound'
   },
 )
+
+export const Compound3Metric = each(
+  {
+    compound_v3_action_deposits: {
+      label: 'Compound v3 Deposits',
+    },
+    compound_v3_action_liquidations: {
+      label: 'Compound v3 Liquidations',
+    },
+    compound_v3_action_new_debt: {
+      label: 'Compound v3 New Debt',
+    },
+    compound_v3_action_repayments: {
+      label: 'Compound v3 Repayments',
+    },
+    compound_v3_action_deposits_usd: {
+      label: 'Compound v3 Deposits in USD',
+      formatter: usdFormatter,
+    },
+    compound_v3_action_liquidations_usd: {
+      label: 'Compound v3 Liquidations in USD',
+      formatter: usdFormatter,
+    },
+    compound_v3_action_new_debt_usd: {
+      label: 'Compound v3 New Debt in USD',
+      formatter: usdFormatter,
+    },
+    compound_v3_action_repayments_usd: {
+      label: 'Compound v3 Repayments in USD',
+      formatter: usdFormatter,
+    },
+    compound_v3_total_deposits_usd: {
+      label: 'Compound v3 Total Deposits in USD',
+      formatter: usdFormatter,
+    },
+    compound_v3_total_liquidations_usd: {
+      label: 'Compound v3 Total Liquidations in USD',
+      formatter: usdFormatter,
+    },
+    compound_v3_total_new_debt_usd: {
+      label: 'Compound v3 Total New Debt in USD',
+      formatter: usdFormatter,
+    },
+    compound_v3_total_repayments_usd: {
+      label: 'Compound v3 Total Repayments in USD',
+      formatter: usdFormatter,
+    },
+    compound_v3_total_supplied: {
+      label: 'Compound v3 Total Supplied',
+    },
+    compound_v3_total_supplied_usd: {
+      label: 'Compound v3 Total Supplied in USD',
+      formatter: usdFormatter,
+    },
+    compound_v3_total_borrowed: {
+      label: 'Compound v3 Total Borrowed',
+    },
+    compound_v3_total_borrowed_usd: {
+      label: 'Compound v3 Total Borrowed in USD',
+      formatter: usdFormatter,
+    },
+    compound_v3_protocol_total_supplied_usd: {
+      label: 'Compound v3 Protocol Total Supplied in USD',
+      formatter: usdFormatter,
+    },
+    compound_v3_protocol_total_borrowed_usd: {
+      label: 'Compound v3 Protocol Total Borrowed in USD',
+      formatter: usdFormatter,
+    },
+    compound_v3_active_addresses: {
+      label: 'Compound v3 Active Addresses',
+    },
+  },
+  (metric: Studio.Metric) => {
+    metric.group = 'Compound v3'
+  },
+)

--- a/src/metrics/_onchain/index.ts
+++ b/src/metrics/_onchain/index.ts
@@ -2,7 +2,7 @@ import { HolderDistributionMetric } from './holderDistributions'
 import { XrpMetric } from './xrp'
 import { MakerDaoMetric } from './makerDao'
 import { AaveMetric, Aave3Metric } from './aave'
-import { CompoundMetric } from './compound'
+import { CompoundMetric, Compound3Metric } from './compound'
 // import { ExchangesV2Metric } from './exchangesV2'
 import { Eth2Metric } from './eth2'
 import { ContractAddressMetric } from './contractAddress'
@@ -387,6 +387,7 @@ export const OnChainMetric = each(
     AaveMetric,
     Aave3Metric,
     CompoundMetric,
+    Compound3Metric,
     BeaconMetric,
 
     NFTMetric,


### PR DESCRIPTION
Add compound v3 metrics:
- action metrics (in asset and in usd)
- total action metrics
- total supplied/borrowed metrics
- total protocol supplied/borrowed metrics
- active addresses