### PR TITLE
Add compound v3 apy metrics to frontend

### DIFF
--- a/src/metrics/_onchain/compound.ts
+++ b/src/metrics/_onchain/compound.ts
@@ -155,6 +155,18 @@ export const Compound3Metric = each(
       label: 'Compound v3 Protocol Total Borrowed in USD',
       formatter: usdFormatter,
     },
+    compound_v3_eth_market_supply_apy: {
+      label: 'Compound v3 ETH market supply APY',
+    },
+    compound_v3_eth_market_borrow_apy: {
+      label: 'Compound v3 ETH market borrow APY',
+    },
+    compound_v3_usdc_market_supply_apy: {
+      label: 'Compound v3 USDC market supply APY',
+    },
+    compound_v3_usdc_market_borrow_apy: {
+      label: 'Compound v3 USDC market borrow APY',
+    },
     compound_v3_active_addresses: {
       label: 'Compound v3 Active Addresses',
     },


### PR DESCRIPTION
Add compound v3 apy metrics to frontend:
- eth market supply/borrow apy
- usdc market supply/borrow apy