### PR TITLE
Fix type of getSignal API

### DIFF
--- a/src/api/signals/index.ts
+++ b/src/api/signals/index.ts
@@ -2,7 +2,7 @@ import { query } from 'webkit/api'
 
 const SIGNAL_QUERY = `
   query getSignal(
-    $signal: String
+    $signal: String!
     $slug: String
     $from: DateTime!
     $to: DateTime!


### PR DESCRIPTION
The preview chart for anomalies (Notables) is broken:
<img width="590" alt="image" src="https://github.com/santiment/san-studio/assets/6518376/c62bb52c-3629-4573-bbc7-cd9be72bf443">
<img width="523" alt="image" src="https://github.com/santiment/san-studio/assets/6518376/652b0c11-ebfa-4d70-ac26-340f516e7f3d">
