### PR TITLE
Add compound revenue metrics to the Sanbase

### DIFF
--- a/src/metrics/_onchain/aave.ts
+++ b/src/metrics/_onchain/aave.ts
@@ -55,13 +55,14 @@ export const AaveMetric = each(
     aave_v2_variable_borrow_apy: {
       label: 'Aave v2 Variable Borrow APY',
     },
-
     aave_v2_revenue: {
       label: 'Aave v2 Revenue',
+      node: 'bar',
     },
     aave_v2_revenue_usd: {
       label: 'Aave v2 Revenue in USD',
       formatter: usdFormatter,
+      node: 'bar',
     },
 
     aave_v2_total_deposits_usd: {
@@ -94,6 +95,7 @@ export const AaveMetric = each(
     aave_v2_total_revenue_usd: {
       label: 'Aave v2 Protocol Total Revenue in USD',
       formatter: usdFormatter,
+      node: 'bar',
     },
     aave_v2_total_cumulative_revenue_usd: {
       label: 'Aave v2 Protocol Total Cumulative Revenue in USD',

--- a/src/metrics/_onchain/aave.ts
+++ b/src/metrics/_onchain/aave.ts
@@ -55,14 +55,13 @@ export const AaveMetric = each(
     aave_v2_variable_borrow_apy: {
       label: 'Aave v2 Variable Borrow APY',
     },
+
     aave_v2_revenue: {
       label: 'Aave v2 Revenue',
-      node: 'bar',
     },
     aave_v2_revenue_usd: {
       label: 'Aave v2 Revenue in USD',
       formatter: usdFormatter,
-      node: 'bar',
     },
 
     aave_v2_total_deposits_usd: {
@@ -95,7 +94,6 @@ export const AaveMetric = each(
     aave_v2_total_revenue_usd: {
       label: 'Aave v2 Protocol Total Revenue in USD',
       formatter: usdFormatter,
-      node: 'bar',
     },
     aave_v2_total_cumulative_revenue_usd: {
       label: 'Aave v2 Protocol Total Cumulative Revenue in USD',

--- a/src/metrics/_onchain/compound.ts
+++ b/src/metrics/_onchain/compound.ts
@@ -51,6 +51,15 @@ export const CompoundMetric = each(
     compound_borrow_apy: {
       label: 'Compound Borrow APY',
     },
+    compound_revenue: {
+      label: 'Compound Revenue',
+      node: 'bar',
+    },
+    compound_revenue_usd: {
+      label: 'Compound Revenue in USD',
+      formatter: usdFormatter,
+      node: 'bar',
+    },
 
     compound_total_deposits_usd: {
       label: 'Compound Protocol Total Deposits in USD',
@@ -78,6 +87,15 @@ export const CompoundMetric = each(
     },
     compound_active_addresses: {
       label: 'Compound Protocol Active Addresses',
+    },
+    compound_total_revenue_usd: {
+      label: 'Compound Protocol Total Revenue in USD',
+      formatter: usdFormatter,
+      node: 'bar',
+    },
+    compound_total_cumulative_revenue_usd: {
+      label: 'Compound Protocol Total Cumulative Revenue in USD',
+      formatter: usdFormatter,
     },
   },
   (metric: Studio.Metric) => {

--- a/src/metrics/_onchain/compound.ts
+++ b/src/metrics/_onchain/compound.ts
@@ -88,12 +88,12 @@ export const CompoundMetric = each(
     compound_active_addresses: {
       label: 'Compound Protocol Active Addresses',
     },
-    compound_total_revenue_usd: {
+    compound_total_protocol_revenue_usd: {
       label: 'Compound Protocol Total Revenue in USD',
       formatter: usdFormatter,
       node: 'bar',
     },
-    compound_total_cumulative_revenue_usd: {
+    compound_total_protocol_cumulative_revenue_usd: {
       label: 'Compound Protocol Total Cumulative Revenue in USD',
       formatter: usdFormatter,
     },


### PR DESCRIPTION
Add compound revenue metrics to the Sanbase:
- compound_revenue
- compound_revenue_usd
- compound_total_protocol_revenue_usd
- compound_total_protocol_cumulative_revenue_usd
