### PR TITLE
fix(styles) Fix save as button arrow alignment

### DIFF
--- a/src/Layouts/index.svelte
+++ b/src/Layouts/index.svelte
@@ -181,7 +181,7 @@
     {layout ? 'Save' : 'Save as'}
   </div>
   <Tooltip on="click" duration={0} align="center" class="$style.tooltip">
-    <div class="menu btn border" slot="trigger">
+    <div class="menu btn border row v-center" slot="trigger">
       <Svg id="arrow" w="8" h="5" class="$style.arrow" />
     </div>
 


### PR DESCRIPTION
## Summary

Fix `save as` button arrow alignment (broken due to tailwind usage)


## Screenshots
![image](https://github.com/santiment/san-studio/assets/25119304/a821e36e-a62f-4690-a919-809c7dfbf571)
