### PR TITLE
Fixes required for Sanbase Svelte 5 update

### DIFF
--- a/src/Chart/Areas.svelte
+++ b/src/Chart/Areas.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable />
-
 <script lang="ts">
   import { plotAreas } from 'san-chart/areas'
   import { getChart } from './context'

--- a/src/Chart/Axes/index.svelte
+++ b/src/Chart/Axes/index.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable />
-
 <script lang="ts">
   import { drawXAxisTicks, drawAxisLine, drawYAxisTicks } from 'san-chart/axes'
   import { drawValueBubbleY } from 'san-chart/tooltip'

--- a/src/Chart/Bars.svelte
+++ b/src/Chart/Bars.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable />
-
 <script lang="ts">
   import { plotBars } from 'san-chart/bars'
   import { getChart } from './context'

--- a/src/Chart/Brush/index.svelte
+++ b/src/Chart/Brush/index.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable />
-
 <script lang="ts">
   import { initBrush, updateBrushState, updateBrushDimensions } from 'san-chart/brush'
   import { getChart } from '../context'

--- a/src/Chart/Candles.svelte
+++ b/src/Chart/Candles.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable />
-
 <script lang="ts">
   import { plotCandles } from '@santiment-network/chart/candles'
   import { getChart } from './context'

--- a/src/Chart/CartesianGrid.svelte
+++ b/src/Chart/CartesianGrid.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable />
-
 <script lang="ts">
   import { onDestroy } from 'svelte'
   import { drawCartesianGrid } from 'san-chart/cartesianGrid'

--- a/src/Chart/Drawer/index.svelte
+++ b/src/Chart/Drawer/index.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable />
-
 <script lang="ts">
   import type { Drawing } from './drawer'
   import { onDestroy } from 'svelte'

--- a/src/Chart/GreenRedBars.svelte
+++ b/src/Chart/GreenRedBars.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable />
-
 <script lang="ts">
   import { plotGreenRedBars } from 'san-chart/bars/greenRedBars'
   import { getChart } from './context'

--- a/src/Chart/Lines.svelte
+++ b/src/Chart/Lines.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable />
-
 <script lang="ts">
   import { plotLines, plotFilledLines, plotGradientLine } from 'san-chart/lines'
   import { getChart } from './context'

--- a/src/Chart/ReferenceDots.svelte
+++ b/src/Chart/ReferenceDots.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable />
-
 <script lang="ts">
   import { drawReferenceDot } from 'san-chart/references'
   import { getChart } from './context'

--- a/src/Chart/Tooltip/index.svelte
+++ b/src/Chart/Tooltip/index.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable />
-
 <script lang="ts">
   import { onDestroy } from 'svelte'
   import {

--- a/src/Chart/TrendingDots.svelte
+++ b/src/Chart/TrendingDots.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable />
-
 <script lang="ts">
   import { getContext } from 'svelte'
   import { getChart } from './context'

--- a/src/Chart/Watermark.svelte
+++ b/src/Chart/Watermark.svelte
@@ -1,5 +1,3 @@
-<svelte:options immutable />
-
 <script lang="ts">
   import { onDestroy } from 'svelte'
   import { getChart } from './context'

--- a/src/ChartWidget/IncompleteData/PaywallDialog.svelte
+++ b/src/ChartWidget/IncompleteData/PaywallDialog.svelte
@@ -26,17 +26,21 @@
 <Dialog {...$$props} title="Incomplete data">
   <dialog-content class="column">
     <table class="fluid border">
-      <tr class="c-fiord">
-        <th>Metric</th>
-        <th>Period of hidden data</th>
-      </tr>
-
-      {#each restrictionsInfo as { metric, date }}
-        <tr>
-          <td>{metric}</td>
-          <td>{date}</td>
+      <thead>
+        <tr class="c-fiord">
+          <th>Metric</th>
+          <th>Period of hidden data</th>
         </tr>
-      {/each}
+      </thead>
+
+      <tbody>
+        {#each restrictionsInfo as { metric, date }}
+          <tr>
+            <td>{metric}</td>
+            <td>{date}</td>
+          </tr>
+        {/each}
+      </tbody>
     </table>
 
     <p class="c-fiord mrg-l mrg--t">

--- a/src/ChartWidget/MetricSettings/ExchangeSetting/index.svelte
+++ b/src/ChartWidget/MetricSettings/ExchangeSetting/index.svelte
@@ -94,7 +94,7 @@
   Exchange: {metricOwner}
 
   <svelte:fragment slot="dropdown">
-    <div slot="header" class="tabs row txt-m mrg-s mrg--b">
+    <div class="tabs row txt-m mrg-s mrg--b">
       {#if !isOpenInterestMetric}
         <div class:tab-active={!isDex} class="tab btn" on:click={() => (isDex = false)}>CEX</div>
         <div class:tab-active={isDex} class="tab btn" on:click={() => (isDex = true)}>DEX</div>

--- a/src/Sidebar/Modes.svelte
+++ b/src/Sidebar/Modes.svelte
@@ -40,8 +40,10 @@
 </script>
 
 <div class="nav row">
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div
-    aria-label="{isLocked ? 'Hide' : 'Lock'} sidebar | {CMD} + \"
+    aria-label="{isLocked ? 'Hide' : 'Lock'} sidebar | {CMD} + \\"
     class="toggle btn row hv-center expl-tooltip"
     on:click={toggleSidebar}
   >


### PR DESCRIPTION
## Summary

1. Table now is required to have proper structure (`table` -> `tbody` -> `tr`). This is svelte 5 breaking change https://github.com/sveltejs/svelte/issues/9785
2. Remove not defined slot in another slot. It causes build error with svelte 5 in Sanbase
3. Fix string escaping causing build error in Sanbase
4. Remove Svelte immutable option in components with `getContext`. It caused wrong structure of object returned in Sanbase and runtime error