### PR TITLE
Add new compound v3 metrics to the Sanbase

### DIFF
--- a/src/metrics/_onchain/compound.ts
+++ b/src/metrics/_onchain/compound.ts
@@ -154,6 +154,13 @@ export const Compound3Metric = each(
       formatter: usdFormatter,
       node: 'bar',
     },
+    compound_v3_collateral_total_supplied: {
+      label: 'Compound v3 Collateral Total Supplied',
+    },
+    compound_v3_collateral_total_supplied_usd: {
+      label: 'Compound v3 Collateral Total Supplied in USD',
+      formatter: usdFormatter,
+    },
     compound_v3_total_supplied: {
       label: 'Compound v3 Total Supplied',
     },
@@ -167,6 +174,12 @@ export const Compound3Metric = each(
     compound_v3_total_borrowed_usd: {
       label: 'Compound v3 Total Borrowed in USD',
       formatter: usdFormatter,
+    },
+    compound_v3_supply_apy: {
+      label: 'Compound v3 Supply APY',
+    },
+    compound_v3_borrow_apy: {
+      label: 'Compound v3 Borrow APY',
     },
 
     compound_v3_total_deposits_usd: {
@@ -196,18 +209,6 @@ export const Compound3Metric = each(
     compound_v3_protocol_total_borrowed_usd: {
       label: 'Compound v3 Protocol Total Borrowed in USD',
       formatter: usdFormatter,
-    },
-    compound_v3_eth_market_supply_apy: {
-      label: 'Compound v3 ETH market supply APY',
-    },
-    compound_v3_eth_market_borrow_apy: {
-      label: 'Compound v3 ETH market borrow APY',
-    },
-    compound_v3_usdc_market_supply_apy: {
-      label: 'Compound v3 USDC market supply APY',
-    },
-    compound_v3_usdc_market_borrow_apy: {
-      label: 'Compound v3 USDC market borrow APY',
     },
     compound_v3_active_addresses: {
       label: 'Compound v3 Protocol Active Addresses',


### PR DESCRIPTION
Add new compound v3 metrics to the Sanbase:
- collateral total supplied metrics
- supply and borrow APY metrics