### PR TITLE
Add Fraxlend total supplied and borrowed metrics to the Sanbase

### DIFF
--- a/src/metrics/_onchain/fraxlend.ts
+++ b/src/metrics/_onchain/fraxlend.ts
@@ -77,8 +77,9 @@ export const FraxlendMetric = each(
       label: 'Fraxlend Protocol Total Supplied in USD',
       formatter: usdFormatter,
     },
-    fraxlend_protocol_total_borrowed: {
-      label: 'Fraxlend Protocol Total FRAX Borrowed',
+    fraxlend_protocol_total_borrowed_usd: {
+      label: 'Fraxlend Protocol Total Borrowed in USD',
+      formatter: usdFormatter,
     },
     fraxlend_active_addresses: {
       label: 'Fraxlend Protocol Active Addresses',

--- a/src/metrics/_onchain/fraxlend.ts
+++ b/src/metrics/_onchain/fraxlend.ts
@@ -39,6 +39,16 @@ export const FraxlendMetric = each(
       formatter: usdFormatter,
       node: 'bar',
     },
+    fraxlend_total_supplied: {
+      label: 'Fraxlend Total Supplied',
+    },
+    fraxlend_total_supplied_usd: {
+      label: 'Fraxlend Total Supplied in USD',
+      formatter: usdFormatter,
+    },
+    fraxlend_total_borrowed_against_collateral: {
+      label: 'Fraxlend Total FRAX Borrowed Against Collateral',
+    },
     fraxlend_borrow_apy: {
       label: 'Fraxlend Borrow APY',
     },
@@ -62,6 +72,13 @@ export const FraxlendMetric = each(
       label: 'Fraxlend Protocol Total Repayments in USD',
       formatter: usdFormatter,
       node: 'bar',
+    },
+    fraxlend_protocol_total_supplied_usd: {
+      label: 'Fraxlend Protocol Total Supplied in USD',
+      formatter: usdFormatter,
+    },
+    fraxlend_protocol_total_borrowed: {
+      label: 'Fraxlend Protocol Total FRAX Borrowed',
     },
     fraxlend_active_addresses: {
       label: 'Fraxlend Protocol Active Addresses',


### PR DESCRIPTION
Add Fraxlend total supplied and borrowed metrics to the Sanbase:
- fraxlend_total_supplied
- fraxlend_total_supplied_usd
- fraxlend_total_borrowed_against_collateral
- fraxlend_protocol_total_supplied_usd
- fraxlend_protocol_total_borrowed_usd