### PR TITLE
Add Pendle markets metrics to the Sanbase

### DIFF
--- a/src/metrics/_onchain/index.ts
+++ b/src/metrics/_onchain/index.ts
@@ -9,6 +9,7 @@ import { SparkMetric } from './spark'
 import { MorphoMetric } from './morpho'
 import { EthenaMetric } from './ethena'
 import { SkySavingsMetric } from './skySavings'
+import { PendleMarketsMetric } from './pendleMarkets'
 import { Eth2Metric } from './eth2'
 import { ContractAddressMetric } from './contractAddress'
 import { MetricCategory } from '@/metrics/graph'
@@ -337,6 +338,7 @@ export const OnChainMetric = each(
     FraxlendMetric,
     EthenaMetric,
     SkySavingsMetric,
+    PendleMarketsMetric,
     BeaconMetric,
 
     NFTMetric,

--- a/src/metrics/_onchain/pendleMarkets.ts
+++ b/src/metrics/_onchain/pendleMarkets.ts
@@ -1,0 +1,27 @@
+import { Node } from '@/Chart/nodes'
+import { each } from '../utils'
+
+export const PendleMarketsMetric = each(
+  {
+    pendle_total_markets_tvl: {
+      label: 'Pendle Total Markets TVL',
+      node: Node.LINE,
+    },
+    pendle_underlying_apy: {
+      label: 'Pendle Underlying APY',
+      node: Node.LINE,
+    },
+    pendle_implied_apy: {
+      label: 'Pendle Implied APY',
+      node: Node.LINE,
+    },
+    pendle_yield_spread: {
+      label: 'Pendle Yield Spread',
+      node: Node.LINE,
+    },
+  },
+  (metric: Studio.Metric) => {
+    metric.group = 'Pendle Markets'
+    metric.node = metric.node || Node.BAR
+  },
+)


### PR DESCRIPTION
Add Pendle markets metrics to the Sanbase:
- pendle_total_markets_tvl
- pendle_underlying_apy
- pendle_implied_apy
- pendle_yield_spread