### PR TITLE
Add BTC and S&P 500 price divergence metric to the Sanbase

### DIFF
--- a/src/metrics/_financial.ts
+++ b/src/metrics/_financial.ts
@@ -48,6 +48,13 @@ const RSIMetric = each(
   () => {},
 )
 
+const BTCSnPPriceDivergenceMetric = each(
+  {
+    btc_s_and_p_price_divergence: { label: 'BTC and S&P 500 Price Divergence' },
+  },
+  () => {},
+)
+
 export const FinancialMetric = each(
   {
     price_usd: {
@@ -81,6 +88,7 @@ export const FinancialMetric = each(
     },
     ...PriceVolatilityMetric,
     ...RSIMetric,
+    ...BTCSnPPriceDivergenceMetric,
     ...NFTPrices,
   },
   (metric: Studio.Metric) => {


### PR DESCRIPTION
Add BTC and S&P 500 price divergence metric to the Sanbase:
- btc_s_and_p_price_divergence