### PR TITLE
Add Aave safety module metrics to the Sanbase

### DIFF
--- a/src/metrics/_onchain/aave.ts
+++ b/src/metrics/_onchain/aave.ts
@@ -234,3 +234,34 @@ export const Aave3Metric = each(
     metric.group = 'Aave v3'
   },
 )
+
+export const AaveSafetyModuleMetric = each(
+  {
+    aave_safety_module_amount: {
+      label: 'Aave Safety Module Staked Amount',
+    },
+    aave_safety_module_amount_usd: {
+      label: 'Aave Safety Module Staked Amount in USD',
+      formatter: usdFormatter,
+    },
+    aave_safety_module_emission_usd: {
+      label: 'Aave Safety Module Emission in USD',
+      formatter: usdFormatter,
+    },
+    aave_safety_module_apr: {
+      label: 'Aave Safety Module APR',
+    },
+
+    aave_safety_module_total_amount_usd: {
+      label: 'Aave Safety Module Total Staked Amount in USD',
+      formatter: usdFormatter,
+    },
+    aave_safety_module_total_emission_usd: {
+      label: 'Aave Safety Module Total Emission in USD',
+      formatter: usdFormatter,
+    },
+  },
+  (metric: Studio.Metric) => {
+    metric.group = 'Aave Safety Module'
+  },
+)

--- a/src/metrics/_onchain/index.ts
+++ b/src/metrics/_onchain/index.ts
@@ -1,7 +1,7 @@
 import { HolderDistributionMetric } from './holderDistributions'
 import { XrpMetric } from './xrp'
 import { MakerDaoMetric, MakerDaoDsrMetric } from './makerDao'
-import { AaveMetric, Aave3Metric } from './aave'
+import { AaveMetric, Aave3Metric, AaveSafetyModuleMetric } from './aave'
 import { CompoundMetric, Compound3Metric } from './compound'
 import { LiquityMetric } from './liquity'
 import { FraxlendMetric } from './fraxlend'
@@ -327,6 +327,7 @@ export const OnChainMetric = each(
     FeesMetric,
 
     Eth2Metric,
+    AaveSafetyModuleMetric,
     AaveMetric,
     Aave3Metric,
     CompoundMetric,


### PR DESCRIPTION
Add Aave safety module metrics to the Sanbase:
- aave_safety_module_amount
- aave_safety_module_amount_usd
- aave_safety_module_emission_usd
- aave_safety_module_apr
- aave_safety_module_total_amount_usd
- aave_safety_module_total_emission_usd